### PR TITLE
fix: lock webpack and  webpack-cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "eosjs-ecc": "^3.0.2",
-    "webpack": "^4.6.0",
-    "webpack-cli": "^2.0.14"
+    "webpack": "4.6.0",
+    "webpack-cli": "2.0.14"
   }
 }


### PR DESCRIPTION
Because the webpack version is upgraded to 4.46 when installing dependencies, and when webpack is greater than 4.20, it depends on webpack-cli 3